### PR TITLE
Make Metadata Creep Map Optional

### DIFF
--- a/sc2image/dataset.py
+++ b/sc2image/dataset.py
@@ -342,11 +342,20 @@ class StarCraftImage(torch.utils.data.Dataset):
         if self.image_size != player_map_state.shape[1]:
             player_map_state = torchvision.transforms.functional.resize(player_map_state,
                                                                 [self.image_size, self.image_size]).type(torch.uint8)
-        return {
-            f'player_{player_idx}_is_visible': player_map_state[0] != 0,
-            f'player_{player_idx}_is_seen': player_map_state[1] != 0,
-            f'player_{player_idx}_creep': player_map_state[2]
-        }
+            
+        # on about 40% of game plays, player_map_state seems to only have length 2 for first index 
+        try:
+            return {
+                f'player_{player_idx}_is_visible': player_map_state[0] != 0,
+                f'player_{player_idx}_is_seen': player_map_state[1] != 0,
+                f'player_{player_idx}_creep': player_map_state[2]
+            }
+        except IndexError:
+            return {
+                f'player_{player_idx}_is_visible': player_map_state[0] != 0,
+                f'player_{player_idx}_is_seen': player_map_state[1] != 0,
+                f'player_{player_idx}_creep': None
+            }
 
     def _get_window_png_path(self, idx):
         md_row = self.metadata.iloc[idx]


### PR DESCRIPTION
I was getting an IndexError when asking for metadata on games without a Zerg player. This error seems to occur whenever you try to return `player_map_state[2]` with creep data in `dataset._build_map_state_dict()`. 

This fix updates the function to return `None` if `player_map_state[2]` raises an IndexError to avoid the issue. 